### PR TITLE
Refactor soft delete comment

### DIFF
--- a/public/detail.html
+++ b/public/detail.html
@@ -298,9 +298,22 @@
                 error: function (req, status, err) {
                     const res = req.responseJSON;
 
-                    if (res && res.message)
-                        alert(res.message);
+                    if (!res) return;
 
+                    if (res.message) {
+                        alert(res.message);
+                    }
+
+                    if (res.deletedCode) {
+                        switch (res.deletedCode) {
+                            case 'post':
+                                window.location.replace(`./index.html`);
+                                break;
+                            case 'comment':
+                                window.location.replace(`./detail.html?id=${postId}`);
+                                break;
+                        }
+                    }
                     return;
                 }
             });
@@ -388,8 +401,22 @@
                     error: function (req, status, err) {
                         const res = req.responseJSON;
 
-                        if (res && res.message)
+                        if (!res) return;
+
+                        if (res.message) {
                             alert(res.message);
+                        }
+
+                        if (res.deletedCode) {
+                            switch (res.deletedCode) {
+                                case 'post':
+                                    window.location.replace(`./index.html`);
+                                    break;
+                                case 'comment':
+                                    window.location.replace(`./detail.html?id=${postId}`);
+                                    break;
+                            }
+                        }
 
                         return;
                     }
@@ -423,8 +450,22 @@
                 error: function (req, status, err) {
                     const res = req.responseJSON;
 
-                    if (res && res.message)
+                    if (!res) return;
+
+                    if (res.message) {
                         alert(res.message);
+                    }
+
+                    if (res.deletedCode) {
+                        switch (res.deletedCode) {
+                            case 'post':
+                                window.location.replace(`./index.html`);
+                                break;
+                            case 'comment':
+                                window.location.replace(`./detail.html?id=${postId}`);
+                                break;
+                        }
+                    }
 
                     return;
                 }
@@ -502,8 +543,22 @@
                 error: function (req, status, err) {
                     const res = req.responseJSON;
 
-                    if (res && res.message)
+                    if (!res) return;
+
+                    if (res.message) {
                         alert(res.message);
+                    }
+
+                    if (res.deletedCode) {
+                        switch (res.deletedCode) {
+                            case 'post':
+                                window.location.replace(`./index.html`);
+                                break;
+                            case 'comment':
+                                window.location.replace(`./detail.html?id=${postId}`);
+                                break;
+                        }
+                    }
 
                     return;
                 }
@@ -564,8 +619,22 @@
                 error: function (req, status, err) {
                     const res = req.responseJSON;
 
-                    if (res && res.message)
+                    if (!res) return;
+
+                    if (res.message) {
                         alert(res.message);
+                    }
+
+                    if (res.deletedCode) {
+                        switch (res.deletedCode) {
+                            case 'post':
+                                window.location.replace(`./index.html`);
+                                break;
+                            case 'comment':
+                                window.location.replace(`./detail.html?id=${postId}`);
+                                break;
+                        }
+                    }
 
                     return;
                 }

--- a/public/post.html
+++ b/public/post.html
@@ -192,8 +192,22 @@
                         error: function (req, status, err) {
                             const res = req.responseJSON;
 
-                            if (res && res.message)
+                            if (!res) return;
+
+                            if (res.message) {
                                 alert(res.message);
+                            }
+
+                            if (res.deletedCode) {
+                                switch (res.deletedCode) {
+                                    case 'post':
+                                        window.location.replace(`./index.html`);
+                                        break;
+                                    case 'comment':
+                                        window.location.replace(`./detail.html?id=${postId}`);
+                                        break;
+                                }
+                            }
                         }
                     });
                 } else {

--- a/src/db/query/comment/comment.db.js
+++ b/src/db/query/comment/comment.db.js
@@ -15,6 +15,12 @@ export const createComment = async ({ author, content, postId }) => {
   ]);
 };
 
+export const getComment = async (id) => {
+  const [row] = await pool.query(SQL_COMMENT_QUERIES.GET_COMMENT, [id]);
+
+  return row[0];
+};
+
 export const editComment = async ({ id, content, author }) => {
   const [row] = await pool.query(SQL_COMMENT_QUERIES.EDIT_COMMENT, [
     content,

--- a/src/db/query/comment/comment.queries.js
+++ b/src/db/query/comment/comment.queries.js
@@ -4,7 +4,7 @@ const SQL_COMMENT_QUERIES = {
   CREATE_COMMENT:
     "INSERT INTO comments (author, content, post_id) VALUES (?,?,?)",
   GET_COMMENT:
-    "SELECT c.id AS id, c.post_id AS postId, author AS authorId, is_deleted AS isDeleted FROM comments WHERE c.id = ?",
+    "SELECT id, post_id AS postId, author AS authorId, is_deleted AS isDeleted FROM comments WHERE id = ?",
   EDIT_COMMENT: "UPDATE comments SET content = ? WHERE id = ? AND author = ?",
   DELETE_COMMENT:
     "UPDATE comments SET is_deleted = TRUE WHERE id = ? AND author = ?",

--- a/src/db/query/comment/comment.queries.js
+++ b/src/db/query/comment/comment.queries.js
@@ -3,6 +3,8 @@ const SQL_COMMENT_QUERIES = {
     "SELECT c.id AS id, u.name AS author, u.id AS authorId, c.content AS content, c.create_dt AS createTime, c.update_dt AS updateTime FROM comments AS c LEFT JOIN users AS u ON c.author = u.id WHERE c.post_id = ? AND c.is_deleted = FALSE",
   CREATE_COMMENT:
     "INSERT INTO comments (author, content, post_id) VALUES (?,?,?)",
+  GET_COMMENT:
+    "SELECT c.id AS id, c.post_id AS postId, author AS authorId, is_deleted AS isDeleted FROM comments WHERE c.id = ?",
   EDIT_COMMENT: "UPDATE comments SET content = ? WHERE id = ? AND author = ?",
   DELETE_COMMENT:
     "UPDATE comments SET is_deleted = TRUE WHERE id = ? AND author = ?",

--- a/src/db/query/comment/comment.queries.js
+++ b/src/db/query/comment/comment.queries.js
@@ -1,10 +1,13 @@
 const SQL_COMMENT_QUERIES = {
   GET_COMMENTS:
-    "SELECT c.id AS id, u.name AS author, u.id AS authorId, c.content AS content, c.create_dt AS createTime, c.update_dt AS updateTime FROM comments AS c LEFT JOIN users AS u ON c.author = u.id WHERE c.post_id = ?",
+    "SELECT c.id AS id, u.name AS author, u.id AS authorId, c.content AS content, c.create_dt AS createTime, c.update_dt AS updateTime FROM comments AS c LEFT JOIN users AS u ON c.author = u.id WHERE c.post_id = ? AND c.is_deleted = FALSE",
   CREATE_COMMENT:
     "INSERT INTO comments (author, content, post_id) VALUES (?,?,?)",
   EDIT_COMMENT: "UPDATE comments SET content = ? WHERE id = ? AND author = ?",
-  DELETE_COMMENT: "DELETE FROM comments WHERE id = ? AND author = ?",
+  DELETE_COMMENT:
+    "UPDATE comments SET is_deleted = TRUE WHERE id = ? AND author = ?",
+  DELETE_COMMENTS_BY_POST_ID:
+    "UPDATE comments SET is_deleted = TRUE WHERE post_id = ?",
   GET_UPDATE_TIME: "SELECT update_dt AS time FROM comments WHERE id =?",
 };
 

--- a/src/db/query/post/post.db.js
+++ b/src/db/query/post/post.db.js
@@ -1,4 +1,5 @@
 import pool from "../../database.js";
+import SQL_COMMENT_QUERIES from "../comment/comment.queries.js";
 import SQL_POST_QUERIES from "./post.queries.js";
 
 export const getAllPosts = async () => {
@@ -37,7 +38,25 @@ export const editPost = async ({ title, content, id, author }) => {
 };
 
 export const deletePost = async ({ id, author }) => {
-  const [row] = await pool.query(SQL_POST_QUERIES.DELETE_POST, [id, author]);
+  const tran = await pool.getConnection();
+  await tran.beginTransaction();
 
-  return row;
+  let result = false;
+
+  if (tran) {
+    try {
+      await tran.query(SQL_POST_QUERIES.DELETE_POST, [id, author]);
+      await tran.query(SQL_COMMENT_QUERIES.DELETE_COMMENTS_BY_POST_ID, [id]);
+      await tran.commit();
+
+      result = true;
+    } catch (err) {
+      console.error(`Transaction error : ${err.message}`);
+      await tran.rollback();
+    } finally {
+      tran.release();
+    }
+  }
+
+  return result;
 };

--- a/src/db/query/post/post.db.js
+++ b/src/db/query/post/post.db.js
@@ -20,6 +20,8 @@ export const createPost = async ({ title, author, content }) => {
 export const getPost = async (id) => {
   const [row] = await pool.query(SQL_POST_QUERIES.GET_POST, [id]);
 
+  console.log(row);
+
   return row[0];
 };
 

--- a/src/db/query/post/post.queries.js
+++ b/src/db/query/post/post.queries.js
@@ -1,9 +1,9 @@
 const SQL_POST_QUERIES = {
   GET_ALL_POSTS:
-    "SELECT p.id AS id, p.title AS title, u.name AS author, p.content AS content, p.create_dt AS createTime, p.update_dt AS updateTime FROM posts AS p LEFT JOIN users AS u ON p.author = u.id;",
+    "SELECT p.id AS id, p.title AS title, u.name AS author, p.content AS content, p.create_dt AS createTime, p.update_dt AS updateTime FROM posts AS p LEFT JOIN users AS u ON p.author = u.id WHERE p.is_deleted = FALSE;",
   CREATE_POST: "INSERT INTO posts (title, author, content) VALUES (?,?,?)",
   GET_POST:
-    "SELECT p.id AS id, p.title AS title, u.id AS userId, u.name AS author, p.content AS content, p.create_dt AS createTime, p.update_dt AS updateTime FROM posts AS p LEFT JOIN users AS u ON p.author = u.id WHERE p.id = ?;",
+    "SELECT p.id AS id, p.title AS title, u.id AS userId, u.name AS author, p.content AS content, p.create_dt AS createTime, p.update_dt AS updateTime, p.is_deleted AS isDeleted FROM posts AS p LEFT JOIN users AS u ON p.author = u.id WHERE p.id = ?;",
   EDIT_POST:
     "UPDATE posts SET title = ?, content = ? WHERE id = ? AND author = ?",
   DELETE_POST: "DELETE FROM posts WHERE id = ? AND author =?",

--- a/src/db/query/post/post.queries.js
+++ b/src/db/query/post/post.queries.js
@@ -6,7 +6,7 @@ const SQL_POST_QUERIES = {
     "SELECT p.id AS id, p.title AS title, u.id AS userId, u.name AS author, p.content AS content, p.create_dt AS createTime, p.update_dt AS updateTime, p.is_deleted AS isDeleted FROM posts AS p LEFT JOIN users AS u ON p.author = u.id WHERE p.id = ?;",
   EDIT_POST:
     "UPDATE posts SET title = ?, content = ? WHERE id = ? AND author = ?",
-  DELETE_POST: "DELETE FROM posts WHERE id = ? AND author =?",
+  DELETE_POST: "UPDATE posts SET is_deleted = TRUE WHERE id = ? AND author =?",
 };
 
 export default SQL_POST_QUERIES;

--- a/src/routes/comment.routes.js
+++ b/src/routes/comment.routes.js
@@ -5,6 +5,7 @@ import {
   editComment,
   deleteComment,
   getUpdateTime,
+  getComment,
 } from "../db/query/comment/comment.db.js";
 import { authMiddleware } from "../middlewares/auth.middleware.js";
 import { getPost } from "../db/query/post/post.db.js";
@@ -128,6 +129,16 @@ router.post(
       if (!author || !content)
         return res.status(400).json({ message: "모든 요소를 작성해주세요." });
 
+      const post = await getPost(postId);
+
+      if (!post)
+        return res
+          .status(404)
+          .json({ message: "해당 게시글이 존재하지 않습니다." });
+
+      if (post.isDeleted)
+        return res.status(404).json({ message: "삭제된 게시글입니다." });
+
       const obj = { author, content, postId };
 
       await createComment(obj);
@@ -193,18 +204,40 @@ router.put("/comments/:commentId", authMiddleware, async (req, res, next) => {
     if (!author || !content)
       return res.status(400).json({ message: "모든 요소를 작성해주세요." });
 
+    const comment = await getComment(commentId);
+
+    if (!comment)
+      return res
+        .status(404)
+        .json({ message: "해당 댓글이 존재하지 않습니다." });
+
+    if (comment.author !== author)
+      return res.status(403).json({ message: "작성자가 아닙니다." });
+
+    if (comment.isDeleted) {
+      const post = await getPost(comment.postId);
+
+      if (!post)
+        return res
+          .status(404)
+          .json({ message: "해당 게시글이 존재하지 않습니다." });
+
+      if (post.isDeleted)
+        return res.status(404).json({ message: "삭제된 게시글입니다." });
+
+      return res.status(404).json({ message: "삭제된 댓글입니다." });
+    }
+
     const obj = {
       id: commentId,
       content,
       author,
     };
 
-    const result = await editComment(obj);
+    await editComment(obj);
 
-    if (result.affectedRows === 0)
-      return res
-        .status(404)
-        .json({ message: "해당 댓글이 존재하지 않습니다." });
+    if (result.changedRows === 0)
+      return res.status(500).json({ message: "댓글 수정에 실패했습니다." });
 
     const time = await getUpdateTime(commentId);
 
@@ -269,14 +302,37 @@ router.delete(
       if (!author)
         return res.status(400).json({ message: "모든 요소를 작성해주세요." });
 
+      // 댓글 및 게시글 검사
+      const comment = await getComment(commentId);
+
+      if (!comment)
+        return res
+          .status(404)
+          .json({ message: "해당 댓글이 존재하지 않습니다." });
+
+      if (comment.author !== author)
+        return res.status(403).json({ message: "작성자가 아닙니다." });
+
+      if (comment.isDeleted) {
+        const post = await getPost(comment.postId);
+
+        if (!post)
+          return res
+            .status(404)
+            .json({ message: "해당 게시글이 존재하지 않습니다." });
+
+        if (post.isDeleted)
+          return res.status(404).json({ message: "삭제된 게시글입니다." });
+
+        return res.status(404).json({ message: "삭제된 댓글입니다." });
+      }
+
       const obj = { id: commentId, author };
 
       const result = await deleteComment(obj);
 
-      if (result.affectedRows === 0)
-        return res
-          .status(404)
-          .json({ message: "해당 댓글이 존재하지 않습니다." });
+      if (result.changedRows === 0)
+        return res.status(500).json({ message: "댓글 삭제에 실패했습니다." });
 
       return res.status(200).json({ message: "댓글이 삭제되었습니다." });
     } catch (err) {

--- a/src/routes/comment.routes.js
+++ b/src/routes/comment.routes.js
@@ -137,7 +137,9 @@ router.post(
           .json({ message: "해당 게시글이 존재하지 않습니다." });
 
       if (post.isDeleted)
-        return res.status(404).json({ message: "삭제된 게시글입니다." });
+        return res
+          .status(404)
+          .json({ deletedCode: "post", message: "삭제된 게시글입니다." });
 
       const obj = { author, content, postId };
 
@@ -211,7 +213,7 @@ router.put("/comments/:commentId", authMiddleware, async (req, res, next) => {
         .status(404)
         .json({ message: "해당 댓글이 존재하지 않습니다." });
 
-    if (comment.author !== author)
+    if (comment.authorId !== author)
       return res.status(403).json({ message: "작성자가 아닙니다." });
 
     if (comment.isDeleted) {
@@ -223,9 +225,13 @@ router.put("/comments/:commentId", authMiddleware, async (req, res, next) => {
           .json({ message: "해당 게시글이 존재하지 않습니다." });
 
       if (post.isDeleted)
-        return res.status(404).json({ message: "삭제된 게시글입니다." });
+        return res
+          .status(404)
+          .json({ deletedCode: "post", message: "삭제된 게시글입니다." });
 
-      return res.status(404).json({ message: "삭제된 댓글입니다." });
+      return res
+        .status(404)
+        .json({ deletedCode: "comment", message: "삭제된 댓글입니다." });
     }
 
     const obj = {
@@ -235,9 +241,6 @@ router.put("/comments/:commentId", authMiddleware, async (req, res, next) => {
     };
 
     await editComment(obj);
-
-    if (result.changedRows === 0)
-      return res.status(500).json({ message: "댓글 수정에 실패했습니다." });
 
     const time = await getUpdateTime(commentId);
 
@@ -310,7 +313,7 @@ router.delete(
           .status(404)
           .json({ message: "해당 댓글이 존재하지 않습니다." });
 
-      if (comment.author !== author)
+      if (comment.authorId !== author)
         return res.status(403).json({ message: "작성자가 아닙니다." });
 
       if (comment.isDeleted) {
@@ -322,17 +325,18 @@ router.delete(
             .json({ message: "해당 게시글이 존재하지 않습니다." });
 
         if (post.isDeleted)
-          return res.status(404).json({ message: "삭제된 게시글입니다." });
+          return res
+            .status(404)
+            .json({ deletedCode: "post", message: "삭제된 게시글입니다." });
 
-        return res.status(404).json({ message: "삭제된 댓글입니다." });
+        return res
+          .status(404)
+          .json({ deletedCode: "comment", message: "삭제된 댓글입니다." });
       }
 
       const obj = { id: commentId, author };
 
-      const result = await deleteComment(obj);
-
-      if (result.changedRows === 0)
-        return res.status(500).json({ message: "댓글 삭제에 실패했습니다." });
+      await deleteComment(obj);
 
       return res.status(200).json({ message: "댓글이 삭제되었습니다." });
     } catch (err) {

--- a/src/routes/post.routes.js
+++ b/src/routes/post.routes.js
@@ -47,6 +47,8 @@ router.get("/posts", async (req, res, next) => {
   try {
     const posts = await getAllPosts();
 
+    console.log(posts);
+
     return res.status(200).json(posts);
   } catch (err) {
     next(err);
@@ -165,7 +167,9 @@ router.get("/posts/:postId", async (req, res, next) => {
         .json({ message: "해당 게시글이 존재하지 않습니다." });
 
     if (post.isDeleted)
-      return res.status(404).json({ message: "삭제된 게시글입니다." });
+      return res
+        .status(404)
+        .json({ deletedCode: "post", message: "삭제된 게시글입니다." });
 
     return res.status(200).json(post);
   } catch (err) {
@@ -240,7 +244,9 @@ router.put("/posts/:postId", authMiddleware, async (req, res, next) => {
     }
 
     if (post.isDeleted)
-      return res.status(404).json({ message: "삭제된 게시글입니다." });
+      return res
+        .status(404)
+        .json({ deletedCode: "post", message: "삭제된 게시글입니다." });
 
     const obj = {
       title,
@@ -249,10 +255,7 @@ router.put("/posts/:postId", authMiddleware, async (req, res, next) => {
       author,
     };
 
-    const result = await editPost(obj);
-
-    if (result.changedRows === 0)
-      return res.status(500).json({ message: "게시글 수정에 실패했습니다." });
+    await editPost(obj);
 
     return res.status(200).json({ message: "게시글이 수정되었습니다." });
   } catch (err) {
@@ -318,7 +321,9 @@ router.delete("/posts/:postId", authMiddleware, async (req, res, next) => {
     }
 
     if (post.isDeleted)
-      return res.status(404).json({ message: "삭제된 게시글입니다." });
+      return res
+        .status(404)
+        .json({ deletedCode: "post", message: "삭제된 게시글입니다." });
 
     const obj = {
       id: postId,

--- a/src/routes/post.routes.js
+++ b/src/routes/post.routes.js
@@ -164,6 +164,9 @@ router.get("/posts/:postId", async (req, res, next) => {
         .status(404)
         .json({ message: "해당 게시글이 존재하지 않습니다." });
 
+    if (post.isDeleted)
+      return res.status(404).json({ message: "게시글이 삭제되었습니다." });
+
     return res.status(200).json(post);
   } catch (err) {
     next(err);
@@ -228,6 +231,17 @@ router.put("/posts/:postId", authMiddleware, async (req, res, next) => {
     if (!title || !author || !content)
       return res.status(400).json({ message: "요소를 전부 입력해주세요." });
 
+    const post = await getPost(postId);
+
+    if (!post) {
+      return res
+        .status(404)
+        .json({ message: "해당 게시글이 존재하지 않습니다." });
+    }
+
+    if (post.isDeleted)
+      return res.status(404).json({ message: "게시글이 삭제되었습니다." });
+
     const obj = {
       title,
       content,
@@ -237,10 +251,10 @@ router.put("/posts/:postId", authMiddleware, async (req, res, next) => {
 
     const result = await editPost(obj);
 
-    if (result.affectedRows === 0)
-      return res
-        .status(404)
-        .json({ message: "해당 게시글이 존재하지 않습니다." });
+    // if (result.affectedRows === 0)
+    //   return res
+    //     .status(404)
+    //     .json({ message: "해당 게시글이 존재하지 않습니다." });
 
     return res.status(200).json({ message: "게시글이 수정되었습니다." });
   } catch (err) {
@@ -296,6 +310,17 @@ router.delete("/posts/:postId", authMiddleware, async (req, res, next) => {
 
     if (isNaN(postId))
       return res.status(400).json({ message: "자료형을 확인해주세요." });
+
+    const post = await getPost(postId);
+
+    if (!post) {
+      return res
+        .status(404)
+        .json({ message: "해당 게시글이 존재하지 않습니다." });
+    }
+
+    if (post.isDeleted)
+      return res.status(404).json({ message: "게시글이 삭제되었습니다." });
 
     const obj = {
       id: postId,

--- a/src/routes/post.routes.js
+++ b/src/routes/post.routes.js
@@ -165,7 +165,7 @@ router.get("/posts/:postId", async (req, res, next) => {
         .json({ message: "해당 게시글이 존재하지 않습니다." });
 
     if (post.isDeleted)
-      return res.status(404).json({ message: "게시글이 삭제되었습니다." });
+      return res.status(404).json({ message: "삭제된 게시글입니다." });
 
     return res.status(200).json(post);
   } catch (err) {
@@ -240,7 +240,7 @@ router.put("/posts/:postId", authMiddleware, async (req, res, next) => {
     }
 
     if (post.isDeleted)
-      return res.status(404).json({ message: "게시글이 삭제되었습니다." });
+      return res.status(404).json({ message: "삭제된 게시글입니다." });
 
     const obj = {
       title,
@@ -320,7 +320,7 @@ router.delete("/posts/:postId", authMiddleware, async (req, res, next) => {
     }
 
     if (post.isDeleted)
-      return res.status(404).json({ message: "게시글이 삭제되었습니다." });
+      return res.status(404).json({ message: "삭제된 게시글입니다." });
 
     const obj = {
       id: postId,
@@ -329,12 +329,13 @@ router.delete("/posts/:postId", authMiddleware, async (req, res, next) => {
 
     const result = await deletePost(obj);
 
-    if (result.affectedRows === 0)
-      return res
-        .status(404)
-        .json({ message: "해당 게시글이 존재하지 않습니다." });
+    if (result) res.status(200).json({ message: "게시글이 삭제되었습니다." });
+    else res.status(500).json({ message: "게시글 삭제에 실패했습니다." });
 
-    return res.status(200).json({ message: "게시글이 삭제되었습니다." });
+    // if (result.affectedRows === 0)
+    //   return res
+    //     .status(404)
+    //     .json({ message: "해당 게시글이 존재하지 않습니다." });
   } catch (err) {
     next(err);
   }

--- a/src/routes/post.routes.js
+++ b/src/routes/post.routes.js
@@ -251,10 +251,8 @@ router.put("/posts/:postId", authMiddleware, async (req, res, next) => {
 
     const result = await editPost(obj);
 
-    // if (result.affectedRows === 0)
-    //   return res
-    //     .status(404)
-    //     .json({ message: "해당 게시글이 존재하지 않습니다." });
+    if (result.changedRows === 0)
+      return res.status(500).json({ message: "게시글 수정에 실패했습니다." });
 
     return res.status(200).json({ message: "게시글이 수정되었습니다." });
   } catch (err) {
@@ -331,11 +329,6 @@ router.delete("/posts/:postId", authMiddleware, async (req, res, next) => {
 
     if (result) res.status(200).json({ message: "게시글이 삭제되었습니다." });
     else res.status(500).json({ message: "게시글 삭제에 실패했습니다." });
-
-    // if (result.affectedRows === 0)
-    //   return res
-    //     .status(404)
-    //     .json({ message: "해당 게시글이 존재하지 않습니다." });
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
요청 -> 댓글을 수정 제출했을 때 만약 글이 삭제된 후라면? 예외처리

문제 1. 현재 delete cascade로 글이 삭제되면 해당 글의 댓글이 테이블에서 아예 사라짐. 따라서 댓글을 제출하면 '해당 댓글이 없습니다.'라는 문구만 뜨고 상세 페이지가 그대로 유지됨.

해야할 일 1. 글이 삭제되었다면, 글이 삭제된 것을 알리고 글 목록으로 이동해야 함.

해결 방안 1-1. 요청 body에 글 아이디를 넣어서 글 존재 조회 후 조건에 맞는 응답 처리

해결 방안 1-2. soft delete로 변경해서 관계 구조를 유지함. 이 경우 params만 보내도 됨. -> 하지만 리팩토링, 트랜잭션 필요.

해결 방안 1-2. 진행.

1) 테이블에 is_deleted 추가
2) 글을 삭제할 때 트랜잭션 soft delete 진행
3) 댓글 삭제할 때 업데이트
4) 글, 댓글 조회 -> is_deleted 아니면 경우만
5) 글 수정, 삭제 중 글 삭제 -> select로 글 존재 여부 판단 후 update 및 delete 
	-> 없으면 글 목록으로 이동
6) 댓글 수정, 삭제 중 댓글 삭제 -> select로 글과 댓글 존재 여부 판단 join으로 ?후 update 및 delete 
	-> 없으면 상세 페이지 새로 고침
7) 댓글 수정, 삭제 중 글 삭제 -> 글이 없으면 글 목록으로 이동